### PR TITLE
docs: missing /v1 from apiBase

### DIFF
--- a/docs/guides/integrations/vscode.mdx
+++ b/docs/guides/integrations/vscode.mdx
@@ -72,7 +72,7 @@ To set up Continue for use with Jan's Local Server, you must activate the Jan AP
       "provider": "openai",
       "model": "mistral-ins-7b-q4",
       "apiKey": "EMPTY",
-      "apiBase": "http://localhost:1337"
+      "apiBase": "http://localhost:1337/v1"
     }
   ]
 }


### PR DESCRIPTION
## Describe Your Changes

Without the /v1 continue hangs indefinitely because it doesn't get the response it is expecting.

## Fixes Issues

I don't believe there are any issues open relating to this currently.

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [x] Updated docs (for bug fixes / features)
- [x] Created issues for follow-up changes or refactoring needed
