### PR TITLE
fix: broken docs link for tensorrt-llm

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -586,3 +586,5 @@ docs/guides/fine-tuning/what-models-can-be-fine-tuned/ /docs 302
 /features /docs 302
 /features/local/ /docs/local-api 302
 /features/local /docs/local-api 302
+/guides/providers/tensorrt-llm /docs/local-inference/tensorrtllm#tensortrt-llm 302
+/guides/providers/tensorrt-llm/ /docs/local-inference/tensorrtllm#tensortrt-llm 302


### PR DESCRIPTION
## Describe Your Changes

- Fixed a broken link in the app that directed users to a TensorRT-LLM guide

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
