### PR TITLE
integrations: adjust llmcord.py config name

### DIFF
--- a/src/pages/integrations/messaging/llmcord.mdx
+++ b/src/pages/integrations/messaging/llmcord.mdx
@@ -60,7 +60,7 @@ pip install -r requirements.txt
 | `DISCORD_BOT_TOKEN`     | Create a new Discord bot at [discord.com/developers/applications](https://discord.com/developers/applications), obtain a token from the Bot tab, and enable MESSAGE CONTENT INTENT. |
 | `DISCORD_CLIENT_ID`     | Found under the OAuth2 tab of the Discord bot you just made. |
 | `LLM`                   | For Jan, set to `local/openai/(MODEL_NAME)`, where `(MODEL_NAME)` is your loaded model's name. |
-| `CUSTOM_SYSTEM_PROMPT`  | Adjust the bot's behavior as needed. |
+| `LLM_SYSTEM_PROMPT`     | Adjust the bot's behavior as needed. |
 | `LOCAL_SERVER_URL`      | URL of your local API server. For Jan, set it to `http://localhost:1337/v1`. |
 
 For more configuration options, refer to llmcord.py's [README](https://github.com/jakobdylanc/discord-llm-chatbot/tree/main?tab=readme-ov-file#instructions).


### PR DESCRIPTION
In llmcord.py, CUSTOM_SYSTEM_PROMPT is now named LLM_SYSTEM_PROMPT. Reflecting this change here.